### PR TITLE
Add typed slice states

### DIFF
--- a/packages/frontend/frontend/src/app/slices/adsSlice.ts
+++ b/packages/frontend/frontend/src/app/slices/adsSlice.ts
@@ -1,8 +1,14 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface Ad {
+  id: string;
+  title: string;
+  content: string;
+}
 
 interface AdsState {
-  ads: any[];
-  currentAd: any;
+  ads: Ad[];
+  currentAd: Ad | null;
   loading: boolean;
   error: string | null;
 }
@@ -18,16 +24,16 @@ const adsSlice = createSlice({
   name: 'ads',
   initialState,
   reducers: {
-    setAds(state, action) {
+    setAds(state, action: PayloadAction<Ad[]>) {
       state.ads = action.payload;
     },
-    setCurrentAd(state, action) {
+    setCurrentAd(state, action: PayloadAction<Ad | null>) {
       state.currentAd = action.payload;
     },
-    setLoading(state, action) {
+    setLoading(state, action: PayloadAction<boolean>) {
       state.loading = action.payload;
     },
-    setError(state, action) {
+    setError(state, action: PayloadAction<string | null>) {
       state.error = action.payload;
     },
     clearError(state) {

--- a/packages/frontend/frontend/src/app/slices/assetsSlice.ts
+++ b/packages/frontend/frontend/src/app/slices/assetsSlice.ts
@@ -1,7 +1,13 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface Asset {
+  id: string;
+  url: string;
+  type: string;
+}
 
 interface AssetsState {
-  assets: any[];
+  assets: Asset[];
   loading: boolean;
   error: string | null;
 }
@@ -16,13 +22,13 @@ const assetsSlice = createSlice({
   name: 'assets',
   initialState,
   reducers: {
-    setAssets(state, action) {
+    setAssets(state, action: PayloadAction<Asset[]>) {
       state.assets = action.payload;
     },
-    setLoading(state, action) {
+    setLoading(state, action: PayloadAction<boolean>) {
       state.loading = action.payload;
     },
-    setError(state, action) {
+    setError(state, action: PayloadAction<string | null>) {
       state.error = action.payload;
     },
     clearError(state) {

--- a/packages/frontend/frontend/src/app/slices/authSlice.ts
+++ b/packages/frontend/frontend/src/app/slices/authSlice.ts
@@ -1,8 +1,27 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface User {
+  id: string;
+  email: string;
+  name: string;
+  role: 'admin' | 'editor' | 'viewer';
+  teams: string[];
+  preferences: {
+    theme: 'light' | 'dark';
+    notifications: boolean;
+  };
+  createdAt: Date;
+  lastLogin?: Date;
+}
+
+interface Tokens {
+  accessToken: string;
+  refreshToken: string;
+}
 
 interface AuthState {
-  user: any;
-  tokens: any;
+  user: User | null;
+  tokens: Tokens | null;
   loading: boolean;
   error: string | null;
 }
@@ -18,16 +37,16 @@ const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setUser(state, action) {
+    setUser(state, action: PayloadAction<User | null>) {
       state.user = action.payload;
     },
     clearUser(state) {
       state.user = null;
     },
-    setLoading(state, action) {
+    setLoading(state, action: PayloadAction<boolean>) {
       state.loading = action.payload;
     },
-    setError(state, action) {
+    setError(state, action: PayloadAction<string | null>) {
       state.error = action.payload;
     },
     clearError(state) {

--- a/packages/frontend/frontend/src/app/slices/projectsSlice.ts
+++ b/packages/frontend/frontend/src/app/slices/projectsSlice.ts
@@ -1,7 +1,13 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface Project {
+  id: string;
+  name: string;
+  description?: string;
+}
 
 interface ProjectsState {
-  projects: any[];
+  projects: Project[];
   loading: boolean;
   error: string | null;
 }
@@ -16,13 +22,13 @@ const projectsSlice = createSlice({
   name: 'projects',
   initialState,
   reducers: {
-    setProjects(state, action) {
+    setProjects(state, action: PayloadAction<Project[]>) {
       state.projects = action.payload;
     },
-    setLoading(state, action) {
+    setLoading(state, action: PayloadAction<boolean>) {
       state.loading = action.payload;
     },
-    setError(state, action) {
+    setError(state, action: PayloadAction<string | null>) {
       state.error = action.payload;
     },
     clearError(state) {

--- a/packages/frontend/frontend/src/app/slices/templatesSlice.ts
+++ b/packages/frontend/frontend/src/app/slices/templatesSlice.ts
@@ -1,7 +1,13 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface Template {
+  id: string;
+  name: string;
+  html: string;
+}
 
 interface TemplatesState {
-  templates: any[];
+  templates: Template[];
   loading: boolean;
   error: string | null;
 }
@@ -16,13 +22,13 @@ const templatesSlice = createSlice({
   name: 'templates',
   initialState,
   reducers: {
-    setTemplates(state, action) {
+    setTemplates(state, action: PayloadAction<Template[]>) {
       state.templates = action.payload;
     },
-    setLoading(state, action) {
+    setLoading(state, action: PayloadAction<boolean>) {
       state.loading = action.payload;
     },
-    setError(state, action) {
+    setError(state, action: PayloadAction<string | null>) {
       state.error = action.payload;
     },
     clearError(state) {

--- a/packages/frontend/frontend/src/app/store.ts
+++ b/packages/frontend/frontend/src/app/store.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import adsReducer from './slices/adsSlice';
 import assetsReducer from './slices/assetsSlice';
@@ -6,8 +6,32 @@ import authReducer from './slices/authSlice';
 import projectsReducer from './slices/projectsSlice';
 import templatesReducer from './slices/templatesSlice';
 
+interface ExampleState {
+  value: number;
+}
+
+const initialExampleState: ExampleState = {
+  value: 0,
+};
+
+const exampleSlice = createSlice({
+  name: 'example',
+  initialState: initialExampleState,
+  reducers: {
+    increment(state) {
+      state.value += 1;
+    },
+    decrement(state) {
+      state.value -= 1;
+    },
+  },
+});
+
+export const { increment, decrement } = exampleSlice.actions;
+
 export const store = configureStore({
   reducer: {
+    example: exampleSlice.reducer,
     auth: authReducer,
     ads: adsReducer,
     templates: templatesReducer,


### PR DESCRIPTION
## Summary
- add strict payload and state typings in Redux slices
- introduce an example slice in the store for Counter tests

## Testing
- `npx nx run-many --target=test --all`

------
https://chatgpt.com/codex/tasks/task_b_68696164f8c88323b785bf31adbbdf3b