### PR TITLE
Add DB_SYNC config

### DIFF
--- a/docs/backend-services.md
+++ b/docs/backend-services.md
@@ -15,6 +15,9 @@ This directory outlines core backend microservices used by the AdCraft platform.
   - Provides `/register`, `/login`, `/refresh` and `/users` endpoints.
   - Issues JWT access and refresh tokens.
   - Persists users via a database using TypeORM.
+  - Set `DB_SYNC` to `true` for local development if you want TypeORM to
+    synchronize entities with the database schema. **Never enable this in
+    production.**
 
 - **Asset Service** (`packages/asset-service`)
 

--- a/docs/project_files/AdCraft - Implementation Guide.md
+++ b/docs/project_files/AdCraft - Implementation Guide.md
@@ -179,8 +179,13 @@ AWS_S3_BUCKET=adcraft-assets
 # Server
 PORT=3000
 NODE_ENV=development
+DB_SYNC=false
 EOL
 ```
+
+> **Warning**
+> Enable `DB_SYNC` only for local development. Schema synchronization can drop
+> or alter tables and should never be used in production.
 
 ### Step 5: Set Up CI/CD with GitHub Actions
 

--- a/packages/auth-service/.env.example
+++ b/packages/auth-service/.env.example
@@ -1,0 +1,7 @@
+PORT=3000
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=password
+DB_DATABASE=auth
+DB_SYNC=false

--- a/packages/auth-service/src/app/app.module.ts
+++ b/packages/auth-service/src/app/app.module.ts
@@ -24,7 +24,7 @@ import { User } from './user.entity';
         password: configService.get<string>('DB_PASSWORD'),
         database: configService.get<string>('DB_DATABASE'),
         autoLoadEntities: true,
-        synchronize: true, // Note: synchronize should be false in production
+        synchronize: configService.get<string>('DB_SYNC', 'false').toLowerCase() === 'true', // do not enable in production
       }),
       inject: [ConfigService],
     }),


### PR DESCRIPTION
## Summary
- control TypeORM synchronize via `DB_SYNC` env var
- document new `DB_SYNC` setting and warn against production use
- provide `.env.example` for the auth service

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npx nx run-many --target=test --all` *(fails: prompts to install nx)*

------
https://chatgpt.com/codex/tasks/task_b_686961726b908323b077a5056c99c12e