### PR TITLE
Add comprehensive tests

### DIFF
--- a/packages/auth-service-e2e/project.json
+++ b/packages/auth-service-e2e/project.json
@@ -7,8 +7,7 @@
       "executor": "@nrwl/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{e2eProjectRoot}"],
       "options": {
-        "jestConfig": "packages/auth-service-e2e/jest.config.ts",
-        "passWithNoTests": true
+        "jestConfig": "packages/auth-service-e2e/jest.config.ts"
       }
     },
     "lint": {

--- a/packages/auth-service/project.json
+++ b/packages/auth-service/project.json
@@ -49,8 +49,7 @@
       "executor": "@nrwl/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "packages/auth-service/jest.config.ts",
-        "passWithNoTests": true
+        "jestConfig": "packages/auth-service/jest.config.ts"
       },
       "configurations": {
         "ci": {

--- a/packages/auth-service/src/app/auth.controller.spec.ts
+++ b/packages/auth-service/src/app/auth.controller.spec.ts
@@ -1,0 +1,53 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication, ValidationPipe, BadRequestException } from '@nestjs/common';
+import * as request from 'supertest';
+
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { RegisterDto } from './dto/register.dto';
+
+describe('AuthController', () => {
+  let app: INestApplication;
+  const service = { register: jest.fn() };
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: service }],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
+    await app.close();
+  });
+
+  it('should register user successfully', async () => {
+    const dto: RegisterDto = { email: 'test@example.com', password: 'password123' };
+    service.register.mockResolvedValue({ id: 1, email: dto.email });
+
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send(dto)
+      .expect(201)
+      .expect({ id: 1, email: dto.email });
+
+    expect(service.register).toHaveBeenCalledWith(dto);
+  });
+
+  it('should return 400 when service throws', async () => {
+    const dto: RegisterDto = { email: 'test@example.com', password: 'password123' };
+    service.register.mockRejectedValue(new BadRequestException('Email already registered'));
+
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send(dto)
+      .expect(400);
+
+    expect(service.register).toHaveBeenCalledWith(dto);
+  });
+});

--- a/packages/frontend/frontend/project.json
+++ b/packages/frontend/frontend/project.json
@@ -56,7 +56,6 @@
       "executor": "@nrwl/vite:test",
       "outputs": ["coverage/packages/frontend/frontend"],
       "options": {
-        "passWithNoTests": true,
         "reportsDirectory": "../../../coverage/packages/frontend/frontend"
       }
     },

--- a/packages/frontend/frontend/src/app/slices/adsSlice.spec.ts
+++ b/packages/frontend/frontend/src/app/slices/adsSlice.spec.ts
@@ -1,0 +1,32 @@
+import reducer, { setAds, setCurrentAd, setLoading, setError, clearError } from './adsSlice';
+
+describe('adsSlice reducer', () => {
+  it('should handle initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({
+      ads: [],
+      currentAd: null,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('should set ads and current ad', () => {
+    const ads = [1, 2];
+    let state = reducer(undefined, setAds(ads));
+    expect(state.ads).toEqual(ads);
+    state = reducer(state, setCurrentAd(2));
+    expect(state.currentAd).toBe(2);
+  });
+
+  it('should handle loading', () => {
+    const state = reducer(undefined, setLoading(true));
+    expect(state.loading).toBe(true);
+  });
+
+  it('should set and clear error', () => {
+    let state = reducer(undefined, setError('err'));
+    expect(state.error).toBe('err');
+    state = reducer(state, clearError());
+    expect(state.error).toBeNull();
+  });
+});

--- a/packages/frontend/frontend/src/app/slices/assetsSlice.spec.ts
+++ b/packages/frontend/frontend/src/app/slices/assetsSlice.spec.ts
@@ -1,0 +1,28 @@
+import reducer, { setAssets, setLoading, setError, clearError } from './assetsSlice';
+
+describe('assetsSlice reducer', () => {
+  it('should handle initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({
+      assets: [],
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('should set assets', () => {
+    const state = reducer(undefined, setAssets([1]));
+    expect(state.assets).toEqual([1]);
+  });
+
+  it('should handle loading', () => {
+    const state = reducer(undefined, setLoading(true));
+    expect(state.loading).toBe(true);
+  });
+
+  it('should set and clear error', () => {
+    let state = reducer(undefined, setError('fail'));
+    expect(state.error).toBe('fail');
+    state = reducer(state, clearError());
+    expect(state.error).toBeNull();
+  });
+});

--- a/packages/frontend/frontend/src/app/slices/authSlice.spec.ts
+++ b/packages/frontend/frontend/src/app/slices/authSlice.spec.ts
@@ -1,0 +1,31 @@
+import reducer, { setUser, clearUser, setLoading, setError, clearError } from './authSlice';
+
+describe('authSlice reducer', () => {
+  it('should handle initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({
+      user: null,
+      tokens: null,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('should set and clear user', () => {
+    let state = reducer(undefined, setUser('test'));
+    expect(state.user).toBe('test');
+    state = reducer(state, clearUser());
+    expect(state.user).toBeNull();
+  });
+
+  it('should handle loading', () => {
+    const state = reducer(undefined, setLoading(true));
+    expect(state.loading).toBe(true);
+  });
+
+  it('should set and clear error', () => {
+    let state = reducer(undefined, setError('oops'));
+    expect(state.error).toBe('oops');
+    state = reducer(state, clearError());
+    expect(state.error).toBeNull();
+  });
+});

--- a/packages/frontend/frontend/src/app/slices/projectsSlice.spec.ts
+++ b/packages/frontend/frontend/src/app/slices/projectsSlice.spec.ts
@@ -1,0 +1,28 @@
+import reducer, { setProjects, setLoading, setError, clearError } from './projectsSlice';
+
+describe('projectsSlice reducer', () => {
+  it('should handle initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({
+      projects: [],
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('should set projects', () => {
+    const state = reducer(undefined, setProjects([1]));
+    expect(state.projects).toEqual([1]);
+  });
+
+  it('should handle loading', () => {
+    const state = reducer(undefined, setLoading(true));
+    expect(state.loading).toBe(true);
+  });
+
+  it('should set and clear error', () => {
+    let state = reducer(undefined, setError('oops'));
+    expect(state.error).toBe('oops');
+    state = reducer(state, clearError());
+    expect(state.error).toBeNull();
+  });
+});

--- a/packages/frontend/frontend/src/app/slices/templatesSlice.spec.ts
+++ b/packages/frontend/frontend/src/app/slices/templatesSlice.spec.ts
@@ -1,0 +1,28 @@
+import reducer, { setTemplates, setLoading, setError, clearError } from './templatesSlice';
+
+describe('templatesSlice reducer', () => {
+  it('should handle initial state', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({
+      templates: [],
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('should set templates', () => {
+    const state = reducer(undefined, setTemplates([1]));
+    expect(state.templates).toEqual([1]);
+  });
+
+  it('should handle loading', () => {
+    const state = reducer(undefined, setLoading(true));
+    expect(state.loading).toBe(true);
+  });
+
+  it('should set and clear error', () => {
+    let state = reducer(undefined, setError('err'));
+    expect(state.error).toBe('err');
+    state = reducer(state, clearError());
+    expect(state.error).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add controller spec for user registration endpoint
- test Redux slice reducers
- enforce test presence in Nx project configs

## Testing
- `npx nx test auth-service` *(fails: Nx not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6869617408a08323bd30272344a48719