### PR TITLE
Add AUTH_ENV_PATH support

### DIFF
--- a/docs/project_files/AdCraft - Implementation Guide.md
+++ b/docs/project_files/AdCraft - Implementation Guide.md
@@ -187,6 +187,10 @@ EOL
 > Enable `DB_SYNC` only for local development. Schema synchronization can drop
 > or alter tables and should never be used in production.
 
+> **Note**
+> The auth service reads configuration from the path specified in `AUTH_ENV_PATH`.
+> If this variable is not set, it defaults to `.env`.
+
 ### Step 5: Set Up CI/CD with GitHub Actions
 
 Create a basic GitHub Actions workflow for CI/CD:

--- a/packages/auth-service/src/app/app.module.ts
+++ b/packages/auth-service/src/app/app.module.ts
@@ -13,7 +13,7 @@ import { User } from './user.entity';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: './packages/auth-service/.env',
+      envFilePath: process.env.AUTH_ENV_PATH || '.env',
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],


### PR DESCRIPTION
## Summary
- allow auth-service to read .env path from `AUTH_ENV_PATH`
- document the new `AUTH_ENV_PATH` environment variable in the implementation guide

## Testing
- `npx nx run-many --target=test --all`

------
https://chatgpt.com/codex/tasks/task_b_68698248a2c4832399d23b12a51c2b86