### PR TITLE
Remove example slice from store and add test

### DIFF
--- a/packages/frontend/frontend/src/app/store.spec.ts
+++ b/packages/frontend/frontend/src/app/store.spec.ts
@@ -1,0 +1,10 @@
+import { store } from './store';
+
+// Checking initial state of store
+
+describe('store initialization', () => {
+  it('should create a store without the example slice', () => {
+    const state = store.getState();
+    expect(state).not.toHaveProperty('example');
+  });
+});

--- a/packages/frontend/frontend/src/app/store.ts
+++ b/packages/frontend/frontend/src/app/store.ts
@@ -1,4 +1,4 @@
-import { configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 
 import adsReducer from './slices/adsSlice';
 import assetsReducer from './slices/assetsSlice';
@@ -6,32 +6,9 @@ import authReducer from './slices/authSlice';
 import projectsReducer from './slices/projectsSlice';
 import templatesReducer from './slices/templatesSlice';
 
-interface ExampleState {
-  value: number;
-}
-
-const initialExampleState: ExampleState = {
-  value: 0,
-};
-
-const exampleSlice = createSlice({
-  name: 'example',
-  initialState: initialExampleState,
-  reducers: {
-    increment(state) {
-      state.value += 1;
-    },
-    decrement(state) {
-      state.value -= 1;
-    },
-  },
-});
-
-export const { increment, decrement } = exampleSlice.actions;
 
 export const store = configureStore({
   reducer: {
-    example: exampleSlice.reducer,
     auth: authReducer,
     ads: adsReducer,
     templates: templatesReducer,


### PR DESCRIPTION
## Summary
- remove unused `exampleSlice` from the Redux store
- add test verifying store initializes without the `example` slice

## Testing
- `npm install --legacy-peer-deps --ignore-scripts --no-progress`
- `npx nx test frontend-frontend`


------
https://chatgpt.com/codex/tasks/task_b_6869866f47fc83238afc4e549de09c64