### PR TITLE
Document NX Cloud token

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ AdCraft/
    nx serve auth-service
    ```
 
+## CI/CD Configuration
+Nx Cloud requires an access token for remote caching. Store this value as the `NX_CLOUD_ACCESS_TOKEN` environment variable and expose it during your build steps.
+
+### GitHub Actions example
+```yaml
+- name: Build
+  run: npx nx affected --target=build
+  env:
+    NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+```
+
 ## State Management
 Redux slices are located in `src/app/slices/`. The store is configured in `src/app/store.ts`.
 

--- a/logbook/2025-07-05-DOCS-003-NxCloudToken.md
+++ b/logbook/2025-07-05-DOCS-003-NxCloudToken.md
@@ -1,0 +1,18 @@
+# Logbook Entry: DOCS-003 - Document Nx Cloud token usage
+
+**Date:** 2025-07-05
+**Agent:** codex
+
+## 1. Task
+Describe how to set the Nx Cloud access token using environment variables and update configuration.
+
+## 2. Plan
+- Replace the placeholder token in `nx.json` with an environment variable reference.
+- Add a documentation section explaining token setup in CI/CD pipelines.
+
+## 3. Actions Taken
+- Updated `nx.json` to use `${NX_CLOUD_ACCESS_TOKEN}` for the Nx Cloud access token.
+- Revised `README.md` with instructions and a GitHub Actions example for exposing the token.
+
+## 4. Outcome
+`nx.json` no longer contains a hard-coded token, and the README now guides users to configure `NX_CLOUD_ACCESS_TOKEN` securely in their pipelines.

--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,7 @@
       "runner": "@nrwl/nx-cloud",
       "options": {
         "cacheableOperations": ["build", "lint", "test", "e2e"],
-        "accessToken": "YOUR_NX_CLOUD_ACCESS_TOKEN"
+        "accessToken": "${NX_CLOUD_ACCESS_TOKEN}"
       }
     }
   },


### PR DESCRIPTION
## Summary
- use an environment variable for Nx Cloud token
- document how to set `NX_CLOUD_ACCESS_TOKEN` in CI/CD environments

## Testing
- `npm test` *(no tests configured)*
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686989d55034832399b8ee0a6c6a95d9