### PR TITLE
Complete frontend tasks

### DIFF
--- a/PROJECT_BOARD.md
+++ b/PROJECT_BOARD.md
@@ -4,13 +4,13 @@ This board tracks all development tasks for the AdCraft v2 project. All work mus
 
 ## To Do
 
-| Task ID      | Description                                               | Priority | Assigned To |
-| :----------- | :-------------------------------------------------------- | :------- | :---------- |
-| **FE-001**   | Scaffold new `frontend` application using React and Vite  | High     | copilot     |
-| **FE-002**   | Implement basic routing with React Router                 | Medium   | copilot     |
-| **FE-003**   | Create a global state management solution (Redux Toolkit) | Medium   | copilot     |
-
-|
+| Task ID    | Description                             | Priority | Assigned To |
+| :--------- | :-------------------------------------- | :------- | :---------- |
+| **FE-006** | Set up protected routes and auth guards | High     | codex       |
+| **FE-007** | Configure Axios with interceptors       | High     | codex       |
+| **FE-008** | Create basic layout components          | Medium   | codex       |
+| **FE-009** | Implement responsive navigation         | Medium   | codex       |
+| **FE-010** | Create unit tests for components        | High     | codex       |
 
 ## In Progress
 
@@ -19,22 +19,27 @@ This board tracks all development tasks for the AdCraft v2 project. All work mus
 
 ## Done
 
-| Task ID      | Description                                                 | Priority | Assigned To | Logbook Entry                                |
-| :----------- | :---------------------------------------------------------- | :------- | :---------- | :------------------------------------------- |
-| **DOCS-001** | Update `README.md` with new project setup instructions      | Medium   | Cline       | `2025-07-03-DOCS-001-ReadmeUpdate.md`        |
-| **AUTH-001** | Scaffold new `auth-service` using NestJS                    | High     | Cline       | `2025-07-05-AUTH-001-AuthServiceScaffold.md` |
-| **AUTH-002** | Implement user registration with password hashing (bcrypt)  | High     | codex       | `2025-07-04-AUTH-002-User-Registration.md`   |
-| **AUTH-005** | Create User entity and repository                           | High     | Cline       | `2025-07-03-AUTH-005-UserEntity.md`          |
-| **AUTH-004** | Set up PostgreSQL database with TypeORM                     | High     | Cline       | `2025-07-05-AUTH-004-PostgresSetupFixed.md`  |
-| **CI-001**   | Create a basic CI pipeline in `.github/workflows/ci.yml`    | High     | Cline       | `2025-07-03-CI-001-PipelineSetup.md`         |
-| **CI-002**   | Add linting and testing steps to CI pipeline                | Medium   | Cline       | `2025-07-03-CI-002-LintTestSteps.md`         |
-| **PROJ-001** | Perform full code audit of original codebase                | Critical | Cline       | `2025-07-03-PROJ-001-CodeAudit.md`           |
-| **PROJ-002** | Demolish old codebase and reset project structure           | Critical | Cline       | `2025-07-03-PROJ-002-ProjectReset.md`        |
-| **PROJ-003** | Establish agent guidelines and project management framework | Critical | Cline       | `2025-07-03-PROJ-003-AgentFramework.md`      |
-| **DOCS-002** | Document PostgreSQL usage for `auth-service`                | Low      | codex       | `2025-07-05-DOCS-002-PostgresUpdate.md`      |
-| **AUTH-006** | Add integration tests for auth service                      | High     | codex       | `2025-07-05-AUTH-006-AuthServiceE2E.md`      |
-| **AUTH-003** | Implement user login and JWT generation | High | codex | `2025-07-06-AUTH-003-LoginFlow.md` |
-| **SEC-001** | Add security middleware (helmet, rate limiting) to auth-service | High | codex | `2025-07-06-SEC-001-SecurityMiddleware.md` |
-| **GW-001** | Scaffold new `api-gateway` using NestJS | High | codex | `2025-07-06-GW-001-ApiGatewayScaffold.md` |
-| **GW-002** | Implement dynamic service discovery | High | codex | `2025-07-06-GW-002-DynamicServiceDiscovery.md` |
-| **GW-003** | Implement JWT validation middleware | High | codex | `2025-07-06-GW-003-JwtValidationMiddleware.md` |
+| Task ID      | Description                                                     | Priority | Assigned To | Logbook Entry                                  |
+| :----------- | :-------------------------------------------------------------- | :------- | :---------- | :--------------------------------------------- |
+| **DOCS-001** | Update `README.md` with new project setup instructions          | Medium   | Cline       | `2025-07-03-DOCS-001-ReadmeUpdate.md`          |
+| **AUTH-001** | Scaffold new `auth-service` using NestJS                        | High     | Cline       | `2025-07-05-AUTH-001-AuthServiceScaffold.md`   |
+| **AUTH-002** | Implement user registration with password hashing (bcrypt)      | High     | codex       | `2025-07-04-AUTH-002-User-Registration.md`     |
+| **AUTH-005** | Create User entity and repository                               | High     | Cline       | `2025-07-03-AUTH-005-UserEntity.md`            |
+| **AUTH-004** | Set up PostgreSQL database with TypeORM                         | High     | Cline       | `2025-07-05-AUTH-004-PostgresSetupFixed.md`    |
+| **CI-001**   | Create a basic CI pipeline in `.github/workflows/ci.yml`        | High     | Cline       | `2025-07-03-CI-001-PipelineSetup.md`           |
+| **CI-002**   | Add linting and testing steps to CI pipeline                    | Medium   | Cline       | `2025-07-03-CI-002-LintTestSteps.md`           |
+| **PROJ-001** | Perform full code audit of original codebase                    | Critical | Cline       | `2025-07-03-PROJ-001-CodeAudit.md`             |
+| **PROJ-002** | Demolish old codebase and reset project structure               | Critical | Cline       | `2025-07-03-PROJ-002-ProjectReset.md`          |
+| **PROJ-003** | Establish agent guidelines and project management framework     | Critical | Cline       | `2025-07-03-PROJ-003-AgentFramework.md`        |
+| **DOCS-002** | Document PostgreSQL usage for `auth-service`                    | Low      | codex       | `2025-07-05-DOCS-002-PostgresUpdate.md`        |
+| **AUTH-006** | Add integration tests for auth service                          | High     | codex       | `2025-07-05-AUTH-006-AuthServiceE2E.md`        |
+| **AUTH-003** | Implement user login and JWT generation                         | High     | codex       | `2025-07-06-AUTH-003-LoginFlow.md`             |
+| **SEC-001**  | Add security middleware (helmet, rate limiting) to auth-service | High     | codex       | `2025-07-06-SEC-001-SecurityMiddleware.md`     |
+| **GW-001**   | Scaffold new `api-gateway` using NestJS                         | High     | codex       | `2025-07-06-GW-001-ApiGatewayScaffold.md`      |
+| **GW-002**   | Implement dynamic service discovery                             | High     | codex       | `2025-07-06-GW-002-DynamicServiceDiscovery.md` |
+| **GW-003**   | Implement JWT validation middleware                             | High     | codex       | `2025-07-06-GW-003-JwtValidationMiddleware.md` |
+| **FE-001**   | Scaffold new `frontend` application using React and Vite        | High     | codex       | `2025-07-06-FE-001-FrontendScaffold.md`        |
+| **FE-002**   | Implement basic routing with React Router                       | Medium   | codex       | `2025-07-06-FE-002-BasicRouting.md`            |
+| **FE-003**   | Create a global state management solution (Redux Toolkit)       | Medium   | codex       | `2025-07-06-FE-003-ReduxStore.md`              |
+| **FE-004**   | Create authentication slice and service                         | Critical | codex       | `2025-07-06-FE-004-AuthSliceService.md`        |
+| **FE-005**   | Implement login and registration forms                          | High     | codex       | `2025-07-06-FE-005-LoginRegistrationForms.md`  |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ The following documents provide a complete overview of the AdCraft project:
 
 - **[Comprehensive Project Plan](./project_files/AdCraft%20-%20Comprehensive%20Project%20Plan.md)**: The main project plan, including a detailed roadmap, sprint breakdowns, and technical implementation details.
 - **[Technical Architecture](./project_files/AdCraft%20-%20Technical%20Architecture.md)**: A detailed overview of the technical architecture, including system components, data flows, and infrastructure design.
+- **Frontend**: Located in `packages/frontend/frontend`, built with React and Vite. Routing is handled by React Router and global state by Redux Toolkit. Authentication is managed with async Redux thunks backed by an `AuthService` and Axios interceptors. Login and registration forms are provided under the auth pages.
 - **[Development Roadmap](./project_files/AdCraft%20-%20Development%20Roadmap.md)**: A high-level roadmap of the project's development timeline.
 - **[Implementation Guide](./project_files/AdCraft%20-%20Implementation%20Guide.md)**: A guide for setting up and running the AdCraft project.
 - **[Testing Strategy](./project_files/AdCraft%20-%20Testing%20Strategy.md)**: The project's testing strategy, including unit, integration, and end-to-end testing.

--- a/docs/project_files/AdCraft - Implementation Guide.md
+++ b/docs/project_files/AdCraft - Implementation Guide.md
@@ -971,9 +971,9 @@ frontend/
 
 - [ ] User schema defined
 - [ ] Authentication service implemented
-- [ ] User registration flow
-- [ ] Login and token management
-- [ ] Frontend authentication components
+- [x] User registration flow
+- [x] Login and token management
+- [x] Frontend authentication components
 
 #### Week 4 Checkpoint: API Gateway & Service Foundation
 

--- a/logbook/2025-07-06-FE-001-FrontendScaffold.md
+++ b/logbook/2025-07-06-FE-001-FrontendScaffold.md
@@ -1,0 +1,17 @@
+# FE-001 Frontend Scaffold
+
+## Task
+
+Scaffold new `frontend` application using React and Vite.
+
+## Plan
+
+Use Nx to generate a React application with Vite.
+
+## Action
+
+Existing repository already contains a frontend app. Confirmed setup with React, Vite and TypeScript. Added initial routing and state management.
+
+## Outcome
+
+Frontend project structure established under `packages/frontend/frontend`.

--- a/logbook/2025-07-06-FE-002-BasicRouting.md
+++ b/logbook/2025-07-06-FE-002-BasicRouting.md
@@ -1,0 +1,17 @@
+# FE-002 Basic Routing
+
+## Task
+
+Implement basic routing with React Router.
+
+## Plan
+
+Add `react-router-dom` routes for Home and About pages.
+
+## Action
+
+Created `Home` and `About` components and updated `App.tsx` to include navigation and route definitions.
+
+## Outcome
+
+Application now renders different pages using React Router.

--- a/logbook/2025-07-06-FE-003-ReduxStore.md
+++ b/logbook/2025-07-06-FE-003-ReduxStore.md
@@ -1,0 +1,17 @@
+# FE-003 Redux Store
+
+## Task
+
+Create a global state management solution with Redux Toolkit.
+
+## Plan
+
+Configure Redux store and example slices.
+
+## Action
+
+Verified `store.ts` with multiple slices using Redux Toolkit. Provided tests ensuring store initializes correctly.
+
+## Outcome
+
+Global Redux store established and integrated with the React application.

--- a/logbook/2025-07-06-FE-004-AuthSliceService.md
+++ b/logbook/2025-07-06-FE-004-AuthSliceService.md
@@ -1,0 +1,17 @@
+# FE-004 Authentication Slice and Service
+
+## Task
+
+Create authentication slice with async actions and build supporting AuthService and Axios client.
+
+## Plan
+
+Implement thunks for login, register, and logout using Redux Toolkit. Add AuthService to manage API calls and apiClient with token refresh logic.
+
+## Action
+
+Added `authSlice` with createAsyncThunk, created `authService.ts`, `apiClient.ts`, and `config.ts`. Updated tests to cover new reducer logic.
+
+## Outcome
+
+Authentication state now supports async actions with persisted tokens. Axios client handles automatic token refresh.

--- a/logbook/2025-07-06-FE-005-LoginRegistrationForms.md
+++ b/logbook/2025-07-06-FE-005-LoginRegistrationForms.md
@@ -1,0 +1,17 @@
+# FE-005 Login and Registration Forms
+
+## Task
+
+Implement login and registration pages using React Hook Form and Redux authentication thunks.
+
+## Plan
+
+Create `Login` and `Register` components with form fields for credentials. Dispatch `login` and `register` thunks on submit. Update routing and navigation.
+
+## Action
+
+Implemented `Login.tsx` and `Register.tsx` pages with simple forms using local state. Updated `App.tsx` routes and navigation. Added tests ensuring both forms render.
+
+## Outcome
+
+Users can now log in and register through the frontend. Tests confirm the pages render as expected.

--- a/packages/frontend/frontend/src/app/app.spec.tsx
+++ b/packages/frontend/frontend/src/app/app.spec.tsx
@@ -25,7 +25,7 @@ describe('App', () => {
         </BrowserRouter>
       </Provider>,
     );
-    expect(getByText(/Welcome frontend-frontend/gi)).toBeTruthy();
+    expect(getByText(/Home Page/i)).toBeTruthy();
+    expect(getByText(/Login/i)).toBeTruthy();
   });
-
 });

--- a/packages/frontend/frontend/src/app/app.tsx
+++ b/packages/frontend/frontend/src/app/app.tsx
@@ -1,10 +1,23 @@
-import NxWelcome from './nx-welcome';
+import { Routes, Route, Link } from 'react-router-dom';
+
+import About from './pages/About';
+import Home from './pages/Home';
+import Login from './pages/Login';
+import Register from './pages/Register';
 
 export function App() {
   return (
     <>
-      <NxWelcome title="frontend-frontend" />
-      <div />
+      <nav>
+        <Link to="/">Home</Link> | <Link to="/about">About</Link> | <Link to="/login">Login</Link> |{' '}
+        <Link to="/register">Register</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+      </Routes>
     </>
   );
 }

--- a/packages/frontend/frontend/src/app/config.ts
+++ b/packages/frontend/frontend/src/app/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env['NX_API_URL'] || 'http://localhost:3000';

--- a/packages/frontend/frontend/src/app/pages/About.tsx
+++ b/packages/frontend/frontend/src/app/pages/About.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function About() {
+  return <h1>About Page</h1>;
+}
+
+export default About;

--- a/packages/frontend/frontend/src/app/pages/Home.tsx
+++ b/packages/frontend/frontend/src/app/pages/Home.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Home() {
+  return <h1>Home Page</h1>;
+}
+
+export default Home;

--- a/packages/frontend/frontend/src/app/pages/Login.spec.tsx
+++ b/packages/frontend/frontend/src/app/pages/Login.spec.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+import Login from './Login';
+import { store } from '../store';
+
+describe('Login page', () => {
+  it('should render email and password fields', () => {
+    const { getByLabelText } = render(
+      <Provider store={store}>
+        <Login />
+      </Provider>,
+    );
+    expect(getByLabelText(/email/i)).toBeTruthy();
+    expect(getByLabelText(/password/i)).toBeTruthy();
+  });
+});

--- a/packages/frontend/frontend/src/app/pages/Login.tsx
+++ b/packages/frontend/frontend/src/app/pages/Login.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { login } from '../slices/authSlice';
+
+import type { AppDispatch, RootState } from '../store';
+
+function Login() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { loading, error } = useSelector((state: RootState) => state.auth);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    dispatch(login({ email, password }));
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      {error && <p>{error}</p>}
+      <label>
+        Email
+        <input
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          aria-label="email"
+        />
+      </label>
+      <label>
+        Password
+        <input
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          aria-label="password"
+        />
+      </label>
+      <button type="submit" disabled={loading}>
+        Login
+      </button>
+    </form>
+  );
+}
+
+export default Login;

--- a/packages/frontend/frontend/src/app/pages/Register.spec.tsx
+++ b/packages/frontend/frontend/src/app/pages/Register.spec.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+import Register from './Register';
+import { store } from '../store';
+
+describe('Register page', () => {
+  it('should render name, email and password fields', () => {
+    const { getByLabelText } = render(
+      <Provider store={store}>
+        <Register />
+      </Provider>,
+    );
+    expect(getByLabelText(/name/i)).toBeTruthy();
+    expect(getByLabelText(/email/i)).toBeTruthy();
+    expect(getByLabelText(/password/i)).toBeTruthy();
+  });
+});

--- a/packages/frontend/frontend/src/app/pages/Register.tsx
+++ b/packages/frontend/frontend/src/app/pages/Register.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { register as registerUser } from '../slices/authSlice';
+
+import type { AppDispatch, RootState } from '../store';
+
+function Register() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { loading, error } = useSelector((state: RootState) => state.auth);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    dispatch(registerUser({ email, password, name }));
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      {error && <p>{error}</p>}
+      <label>
+        Name
+        <input value={name} onChange={e => setName(e.target.value)} aria-label="name" />
+      </label>
+      <label>
+        Email
+        <input
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          aria-label="email"
+        />
+      </label>
+      <label>
+        Password
+        <input
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          aria-label="password"
+        />
+      </label>
+      <button type="submit" disabled={loading}>
+        Register
+      </button>
+    </form>
+  );
+}
+
+export default Register;

--- a/packages/frontend/frontend/src/app/services/apiClient.ts
+++ b/packages/frontend/frontend/src/app/services/apiClient.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+
+import { AuthService } from './authService';
+import { API_URL } from '../config';
+
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+apiClient.interceptors.request.use(
+  config => {
+    const token = localStorage.getItem('accessToken');
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  error => Promise.reject(error),
+);
+
+apiClient.interceptors.response.use(
+  response => response,
+  async error => {
+    const originalRequest = error.config;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const { tokens } = await AuthService.refreshToken();
+        originalRequest.headers.Authorization = `Bearer ${tokens.accessToken}`;
+        return apiClient(originalRequest);
+      } catch (refreshError) {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default apiClient;

--- a/packages/frontend/frontend/src/app/services/authService.ts
+++ b/packages/frontend/frontend/src/app/services/authService.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+
+import { API_URL } from '../config';
+
+export class AuthService {
+  static login(credentials: { email: string; password: string }) {
+    return axios.post(`${API_URL}/auth/login`, credentials);
+  }
+
+  static register(userData: { email: string; password: string; name: string }) {
+    return axios.post(`${API_URL}/auth/register`, userData);
+  }
+
+  static logout() {
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    return Promise.resolve();
+  }
+
+  static async refreshToken() {
+    const refreshToken = localStorage.getItem('refreshToken');
+    if (!refreshToken) {
+      throw new Error('No refresh token available');
+    }
+
+    const response = await axios.post(
+      `${API_URL}/auth/refresh`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+        },
+      },
+    );
+
+    localStorage.setItem('accessToken', response.data.tokens.accessToken);
+    localStorage.setItem('refreshToken', response.data.tokens.refreshToken);
+
+    return response.data;
+  }
+
+  static getAuthHeader() {
+    const token = localStorage.getItem('accessToken');
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }
+}

--- a/packages/frontend/frontend/src/app/slices/authSlice.spec.ts
+++ b/packages/frontend/frontend/src/app/slices/authSlice.spec.ts
@@ -1,4 +1,4 @@
-import reducer, { setUser, clearUser, setLoading, setError, clearError } from './authSlice';
+import reducer, { login, clearError, User, Tokens } from './authSlice';
 
 describe('authSlice reducer', () => {
   it('should handle initial state', () => {
@@ -10,21 +10,30 @@ describe('authSlice reducer', () => {
     });
   });
 
-  it('should set and clear user', () => {
-    let state = reducer(undefined, setUser('test'));
-    expect(state.user).toBe('test');
-    state = reducer(state, clearUser());
-    expect(state.user).toBeNull();
-  });
-
-  it('should handle loading', () => {
-    const state = reducer(undefined, setLoading(true));
+  it('should handle login lifecycle', () => {
+    let state = reducer(undefined, login.pending('', { email: 'a', password: 'b' }));
     expect(state.loading).toBe(true);
+    const payload = {
+      user: {
+        id: '1',
+        email: 'a',
+        name: 'A',
+        role: 'admin',
+        teams: [],
+        preferences: { theme: 'light', notifications: true },
+        createdAt: new Date(),
+      } as User,
+      tokens: { accessToken: 'x', refreshToken: 'y' } as Tokens,
+    };
+    state = reducer(state, login.fulfilled(payload, '', { email: 'a', password: 'b' }));
+    expect(state.loading).toBe(false);
+    expect(state.user).toEqual(payload.user);
+    expect(state.tokens).toEqual(payload.tokens);
   });
 
-  it('should set and clear error', () => {
-    let state = reducer(undefined, setError('oops'));
-    expect(state.error).toBe('oops');
+  it('should clear error', () => {
+    let state = reducer(undefined, login.rejected(new Error(), '', { email: 'a', password: 'b' }));
+    expect(state.error).toBe('Login failed');
     state = reducer(state, clearError());
     expect(state.error).toBeNull();
   });

--- a/packages/frontend/frontend/src/app/slices/authSlice.ts
+++ b/packages/frontend/frontend/src/app/slices/authSlice.ts
@@ -1,6 +1,8 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 
-interface User {
+import { AuthService } from '../services/authService';
+
+export interface User {
   id: string;
   email: string;
   name: string;
@@ -14,7 +16,7 @@ interface User {
   lastLogin?: Date;
 }
 
-interface Tokens {
+export interface Tokens {
   accessToken: string;
   refreshToken: string;
 }
@@ -33,27 +35,93 @@ const initialState: AuthState = {
   error: null,
 };
 
+export const login = createAsyncThunk(
+  'auth/login',
+  async (credentials: { email: string; password: string }, { rejectWithValue }) => {
+    try {
+      const response = await AuthService.login(credentials);
+      return response.data as { user: User; tokens: Tokens };
+    } catch (error: unknown) {
+      const err = error as { response?: { data: string } };
+      return rejectWithValue(err.response?.data || 'Login failed');
+    }
+  },
+);
+
+export const register = createAsyncThunk(
+  'auth/register',
+  async (userData: { email: string; password: string; name: string }, { rejectWithValue }) => {
+    try {
+      const response = await AuthService.register(userData);
+      return response.data as { user: User; tokens: Tokens };
+    } catch (error: unknown) {
+      const err = error as { response?: { data: string } };
+      return rejectWithValue(err.response?.data || 'Registration failed');
+    }
+  },
+);
+
+export const logout = createAsyncThunk('auth/logout', async (_, { rejectWithValue }) => {
+  try {
+    await AuthService.logout();
+    return null;
+  } catch (error: unknown) {
+    const err = error as { response?: { data: string } };
+    return rejectWithValue(err.response?.data || 'Logout failed');
+  }
+});
+
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setUser(state, action: PayloadAction<User | null>) {
-      state.user = action.payload;
-    },
-    clearUser(state) {
-      state.user = null;
-    },
-    setLoading(state, action: PayloadAction<boolean>) {
-      state.loading = action.payload;
-    },
-    setError(state, action: PayloadAction<string | null>) {
-      state.error = action.payload;
-    },
     clearError(state) {
       state.error = null;
     },
   },
+  extraReducers: builder => {
+    builder
+      .addCase(login.pending, state => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(login.fulfilled, (state, action: PayloadAction<{ user: User; tokens: Tokens }>) => {
+        state.loading = false;
+        state.user = action.payload.user;
+        state.tokens = action.payload.tokens;
+        localStorage.setItem('accessToken', action.payload.tokens.accessToken);
+        localStorage.setItem('refreshToken', action.payload.tokens.refreshToken);
+      })
+      .addCase(login.rejected, (state, action) => {
+        state.loading = false;
+        state.error = (action.payload as string) || 'Login failed';
+      })
+      .addCase(register.pending, state => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(
+        register.fulfilled,
+        (state, action: PayloadAction<{ user: User; tokens: Tokens }>) => {
+          state.loading = false;
+          state.user = action.payload.user;
+          state.tokens = action.payload.tokens;
+          localStorage.setItem('accessToken', action.payload.tokens.accessToken);
+          localStorage.setItem('refreshToken', action.payload.tokens.refreshToken);
+        },
+      )
+      .addCase(register.rejected, (state, action) => {
+        state.loading = false;
+        state.error = (action.payload as string) || 'Registration failed';
+      })
+      .addCase(logout.fulfilled, state => {
+        state.user = null;
+        state.tokens = null;
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+      });
+  },
 });
 
-export const { setUser, clearUser, setLoading, setError, clearError } = authSlice.actions;
+export const { clearError } = authSlice.actions;
 export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- add login and register pages with Redux hooks
- wire auth routes into the app navigation
- track FE-005 completion and add future tasks to board
- document new auth pages in docs and implementation guide

## Testing
- `npx nx lint frontend-frontend --fix`
- `npx nx test frontend-frontend`


------
https://chatgpt.com/codex/tasks/task_b_6869daa617b483239bec907a4925158b