### PR TITLE
Refine backend Docker builds

### DIFF
--- a/packages/api-gateway/Dockerfile
+++ b/packages/api-gateway/Dockerfile
@@ -1,9 +1,12 @@
 # Multi-stage build for api-gateway
-FROM node:18-alpine AS build
+FROM node:18-alpine AS deps
 WORKDIR /app
-COPY package*.json ./
+COPY package*.json nx.json tsconfig.base.json tsconfig.json babel.config.json ./
 RUN npm ci --legacy-peer-deps
-COPY . .
+
+FROM deps AS build
+COPY libs ./libs
+COPY packages/api-gateway ./packages/api-gateway
 RUN npx nx build api-gateway --prod
 
 FROM node:18-alpine AS prod

--- a/packages/auth-service/Dockerfile
+++ b/packages/auth-service/Dockerfile
@@ -1,9 +1,12 @@
 # Multi-stage build for auth-service
-FROM node:18-alpine AS build
+FROM node:18-alpine AS deps
 WORKDIR /app
-COPY package*.json ./
+COPY package*.json nx.json tsconfig.base.json tsconfig.json babel.config.json ./
 RUN npm ci --legacy-peer-deps
-COPY . .
+
+FROM deps AS build
+COPY libs ./libs
+COPY packages/auth-service ./packages/auth-service
 RUN npx nx build auth-service --prod
 
 FROM node:18-alpine AS prod


### PR DESCRIPTION
## Summary
- refine service-specific Dockerfiles to copy only required files
- leverage Nx for building each backend service

## Testing
- `npm ci --legacy-peer-deps`
- `npx nx run-many --target=test --all`

------
https://chatgpt.com/codex/tasks/task_b_6873f6e4e6d48329bfaa829c928d4b42